### PR TITLE
fix(gmail): include label history and expand threads for SELECTED_FOLDERS incremental sync

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-history.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-history.service.spec.ts
@@ -72,6 +72,36 @@ describe('GmailGetHistoryService', () => {
       expect(mockClient.users.history.list).toHaveBeenCalledTimes(2);
     });
 
+
+    it('should request message and label history types by default', async () => {
+      const list = jest.fn().mockResolvedValue({
+        data: {
+          history: [],
+          historyId: '200',
+        },
+      });
+      const mockClient = {
+        users: {
+          history: {
+            list,
+          },
+        },
+      } as unknown as gmail_v1.Gmail;
+
+      await service.getHistory(mockClient, '100');
+
+      expect(list).toHaveBeenCalledWith(
+        expect.objectContaining({
+          historyTypes: [
+            'messageAdded',
+            'messageDeleted',
+            'labelAdded',
+            'labelRemoved',
+          ],
+        }),
+      );
+    });
+
     it('should throw SYNC_CURSOR_ERROR when historyId is expired', async () => {
       const error = { code: 404, message: 'Not found' };
       const mockClient = {
@@ -127,6 +157,21 @@ describe('GmailGetHistoryService', () => {
 
       expect(result.messagesAdded).toEqual(['add1']);
       expect(result.messagesDeleted).toEqual(['del1']);
+    });
+
+
+    it('should include label mutations in extracted message IDs', async () => {
+      const history: gmail_v1.Schema$History[] = [
+        {
+          labelsAdded: [{ message: { id: 'labelAdd1' } }],
+          labelsRemoved: [{ message: { id: 'labelDel1' } }],
+        },
+      ];
+
+      const result = await service.getMessageIdsFromHistory(history);
+
+      expect(result.messagesAdded).toEqual(['labelAdd1']);
+      expect(result.messagesDeleted).toEqual(['labelDel1']);
     });
 
     it('should deduplicate messages that appear in both lists', async () => {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-history.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-history.service.ts
@@ -14,7 +14,12 @@ export class GmailGetHistoryService {
   public async getHistory(
     gmailClient: gmail_v1.Gmail,
     lastSyncHistoryId: string,
-    historyTypes?: ('messageAdded' | 'messageDeleted')[],
+    historyTypes?: (
+      | 'messageAdded'
+      | 'messageDeleted'
+      | 'labelAdded'
+      | 'labelRemoved'
+    )[],
     labelId?: string,
   ): Promise<{
     history: gmail_v1.Schema$History[];
@@ -32,7 +37,12 @@ export class GmailGetHistoryService {
           maxResults: MESSAGING_GMAIL_USERS_HISTORY_MAX_RESULT,
           pageToken,
           startHistoryId: lastSyncHistoryId,
-          historyTypes: historyTypes || ['messageAdded', 'messageDeleted'],
+          historyTypes: historyTypes || [
+            'messageAdded',
+            'messageDeleted',
+            'labelAdded',
+            'labelRemoved',
+          ],
           labelId,
         })
         .catch((error) => {
@@ -78,12 +88,22 @@ export class GmailGetHistoryService {
           (messageAdded) => messageAdded.message?.id || '',
         );
 
+        const labelsAdded = history.labelsAdded?.map(
+          (labelAdded) => labelAdded.message?.id || '',
+        );
+
         const messagesDeleted = history.messagesDeleted?.map(
           (messageDeleted) => messageDeleted.message?.id || '',
         );
 
+        const labelsRemoved = history.labelsRemoved?.map(
+          (labelRemoved) => labelRemoved.message?.id || '',
+        );
+
         if (messagesAdded) acc.messagesAdded.push(...messagesAdded);
+        if (labelsAdded) acc.messagesAdded.push(...labelsAdded);
         if (messagesDeleted) acc.messagesDeleted.push(...messagesDeleted);
+        if (labelsRemoved) acc.messagesDeleted.push(...labelsRemoved);
 
         return acc;
       },

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts
@@ -29,6 +29,7 @@ const createMockFolder = (
 describe('GmailGetMessageListService', () => {
   let service: GmailGetMessageListService;
   let oAuth2ClientManagerService: OAuth2ClientManagerService;
+  let gmailGetHistoryService: GmailGetHistoryService;
 
   const mockConnectedAccount: Pick<
     ConnectedAccountWorkspaceEntity,
@@ -78,6 +79,9 @@ describe('GmailGetMessageListService', () => {
     );
     oAuth2ClientManagerService = module.get<OAuth2ClientManagerService>(
       OAuth2ClientManagerService,
+    );
+    gmailGetHistoryService = module.get<GmailGetHistoryService>(
+      GmailGetHistoryService,
     );
   });
 
@@ -294,6 +298,87 @@ describe('GmailGetMessageListService', () => {
 
       expect(result[0].messageExternalIds).toHaveLength(0);
       expect(mockGmailClient.users.messages.list).toHaveBeenCalledTimes(1);
+    });
+
+
+
+    it('should import full thread for selected folders when history only contains unlabeled reply', async () => {
+      const mockGmailClient = {
+        users: {
+          messages: {
+            get: jest
+              .fn()
+              .mockResolvedValueOnce({
+                data: {
+                  id: 'reply-message',
+                  threadId: 'thread-1',
+                  labelIds: ['INBOX'],
+                },
+              })
+              .mockResolvedValueOnce({
+                data: {
+                  id: 'reply-message-2',
+                  threadId: 'thread-1',
+                  labelIds: ['INBOX'],
+                },
+              }),
+          },
+          threads: {
+            get: jest.fn().mockResolvedValue({
+              data: {
+                messages: [
+                  {
+                    id: 'initial-message',
+                    labelIds: ['Label_custom'],
+                  },
+                  {
+                    id: 'reply-message',
+                    labelIds: ['INBOX'],
+                  },
+                ],
+              },
+            }),
+          },
+        },
+      };
+
+      jest.spyOn(google, 'gmail').mockReturnValue(mockGmailClient as never);
+
+      (
+        oAuth2ClientManagerService.getGoogleOAuth2Client as jest.Mock
+      ).mockResolvedValue({});
+
+      (gmailGetHistoryService.getHistory as jest.Mock).mockResolvedValue({
+        history: [{ labelsAdded: [{ message: { id: 'reply-message' } }] }],
+        historyId: 'next-history-id',
+      });
+      (gmailGetHistoryService.getMessageIdsFromHistory as jest.Mock).mockResolvedValue({
+        messagesAdded: ['reply-message'],
+        messagesDeleted: [],
+      });
+
+      const result = await service.getMessageLists({
+        messageChannel: {
+          syncCursor: 'history-123',
+          id: 'channel-1',
+          messageFolderImportPolicy: MessageFolderImportPolicy.SELECTED_FOLDERS,
+        },
+        connectedAccount: mockConnectedAccount,
+        messageFolders: [
+          createMockFolder({
+            name: 'Custom',
+            externalId: 'Label_custom',
+            isSynced: true,
+          }),
+        ],
+      });
+
+      expect(result[0].messageExternalIds).toEqual(
+        expect.arrayContaining(['initial-message', 'reply-message']),
+      );
+      expect(mockGmailClient.users.threads.get).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 'thread-1' }),
+      );
     });
 
     it('should return empty array when no folders have isSynced=true with SELECTED_FOLDERS policy', async () => {

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 
 import { isNonEmptyString } from '@sniptt/guards';
-import { google } from 'googleapis';
+import { batchFetchImplementation } from '@jrmdayn/googleapis-batcher';
+import { google, type gmail_v1 } from 'googleapis';
 
 import { OAuth2ClientManagerService } from 'src/modules/connected-account/oauth2-client-manager/services/oauth2-client-manager.service';
 import { type ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
@@ -20,6 +21,9 @@ import { GmailMessageListFetchErrorHandler } from 'src/modules/messaging/message
 import { computeGmailExcludeSearchFilter } from 'src/modules/messaging/message-import-manager/drivers/gmail/utils/compute-gmail-exclude-search-filter.util';
 import { type GetMessageListsArgs } from 'src/modules/messaging/message-import-manager/types/get-message-lists-args.type';
 import { type GetMessageListsResponse } from 'src/modules/messaging/message-import-manager/types/get-message-lists-response.type';
+
+
+const GMAIL_BATCH_REQUEST_MAX_SIZE = 50;
 
 @Injectable()
 export class GmailGetMessageListService {
@@ -145,6 +149,99 @@ export class GmailGetMessageListService {
     ];
   }
 
+  private async getMessageExternalIdsForSelectedFoldersByThread(
+    gmailClient: gmail_v1.Gmail,
+    oAuth2Client: unknown,
+    messageExternalIds: string[],
+    messageFolders: Pick<
+      MessageFolderWorkspaceEntity,
+      'name' | 'externalId' | 'isSynced' | 'parentFolderId'
+    >[],
+  ): Promise<string[]> {
+    const syncedFolderExternalIds = messageFolders
+      .filter((folder) => folder.isSynced)
+      .map((folder) => folder.externalId)
+      .filter(isNonEmptyString);
+
+    if (
+      syncedFolderExternalIds.length === 0 ||
+      messageExternalIds.length === 0
+    ) {
+      return [];
+    }
+
+    const batchedFetchImplementation = batchFetchImplementation({
+      maxBatchSize: GMAIL_BATCH_REQUEST_MAX_SIZE,
+    });
+
+    const batchedGmailClient = google.gmail({
+      version: 'v1',
+      auth: oAuth2Client,
+      fetchImplementation: batchedFetchImplementation,
+    });
+
+    const messagesMetadata = await Promise.all(
+      messageExternalIds.map((messageExternalId) =>
+        batchedGmailClient.users.messages
+          .get({
+            userId: 'me',
+            id: messageExternalId,
+            format: 'metadata',
+            metadataHeaders: [],
+          })
+          .then((response) => response.data)
+          .catch((error) => {
+            this.gmailMessageListFetchErrorHandler.handleError(error);
+
+            return null;
+          }),
+      ),
+    );
+
+    const selectedMessageExternalIds = new Set<string>();
+
+    for (const messageMetadata of messagesMetadata) {
+      const messageThreadId = messageMetadata?.threadId;
+
+      if (!isNonEmptyString(messageThreadId)) {
+        continue;
+      }
+
+      const thread = await gmailClient.users.threads
+        .get({
+          userId: 'me',
+          id: messageThreadId,
+          format: 'metadata',
+          metadataHeaders: [],
+        })
+        .catch((error) => {
+          this.gmailMessageListFetchErrorHandler.handleError(error);
+
+          return null;
+        });
+
+      const threadMessages = thread?.data?.messages ?? [];
+      const threadShouldBeImported = threadMessages.some((threadMessage) =>
+        (threadMessage.labelIds ?? []).some((labelId) =>
+          syncedFolderExternalIds.includes(labelId),
+        ),
+      );
+
+      if (!threadShouldBeImported) {
+        continue;
+      }
+
+      for (const threadMessage of threadMessages) {
+        if (isNonEmptyString(threadMessage.id)) {
+          selectedMessageExternalIds.add(threadMessage.id);
+        }
+      }
+    }
+
+    return Array.from(selectedMessageExternalIds);
+  }
+
+
   public async getMessageLists({
     messageChannel,
     connectedAccount,
@@ -191,6 +288,17 @@ export class GmailGetMessageListService {
     const { messagesAdded, messagesDeleted } =
       await this.gmailGetHistoryService.getMessageIdsFromHistory(history);
 
+    const messageExternalIds =
+      messageChannel.messageFolderImportPolicy ===
+      MessageFolderImportPolicy.SELECTED_FOLDERS
+        ? await this.getMessageExternalIdsForSelectedFoldersByThread(
+            gmailClient,
+            oAuth2Client,
+            messagesAdded,
+            messageFolders,
+          )
+        : messagesAdded;
+
     if (!nextSyncCursor) {
       throw new MessageImportDriverException(
         `No nextSyncCursor found for connected account ${connectedAccount.id}`,
@@ -200,7 +308,7 @@ export class GmailGetMessageListService {
 
     return [
       {
-        messageExternalIds: messagesAdded,
+        messageExternalIds,
         messageExternalIdsToDelete: messagesDeleted,
         previousSyncCursor: messageChannel.syncCursor,
         nextSyncCursor,


### PR DESCRIPTION
### Motivation
- Fix Gmail incremental-sync gaps when `messageFolderImportPolicy` is `SELECTED_FOLDERS` so label changes and replies don't get silently missed by the sync cursor.
- Ensure label mutations (relabelling) after the last cursor and replies that lack the custom label themselves still cause the thread to be imported.

### Description
- Include Gmail `labelAdded` and `labelRemoved` history types by default in `GmailGetHistoryService.getHistory` so label changes are returned by the history API.
- Extend `GmailGetHistoryService.getMessageIdsFromHistory` to treat `labelsAdded` as added candidates and `labelsRemoved` as deleted candidates alongside `messagesAdded` / `messagesDeleted`.
- Add thread-expansion logic in `GmailGetMessageListService` for `SELECTED_FOLDERS`: batch-fetch message metadata for history message IDs (using the batched fetch client), fetch thread metadata, and include all thread messages when any thread message matches a synced folder label; this imports initial messages from threads where only a reply without the custom label appeared in history.
- Wire the expansion into `getMessageLists` so incremental `messagesAdded` become the expanded set when `messageFolderImportPolicy` is `SELECTED_FOLDERS`.
- Add unit tests covering: default history types include label events, label mutation extraction in history parsing, and selected-folder behavior where a history-only unlabeled reply causes the whole thread to be returned for import.

### Testing
- Added unit tests for `GmailGetHistoryService` and `GmailGetMessageListService` validating the new behaviors (history default types, label mutation extraction, and thread expansion for selected folders).
- Attempted to run the new specs in this environment with `yarn jest ... --runInBand` but the workspace dependencies / node_modules state are not available so the test run could not be executed here (install required); `pnpm` invocation also failed due to missing test runner in the environment.
- The new tests are included in the branch and should be run in CI or a developer environment with dependencies installed to verify green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e8462af048322b2e6d7ab81f6769f)