### PR TITLE
fix(gmail): include label and thread changes in SELECTED_FOLDERS incremental sync

### DIFF
--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-history.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-history.service.ts
@@ -14,7 +14,12 @@ export class GmailGetHistoryService {
   public async getHistory(
     gmailClient: gmail_v1.Gmail,
     lastSyncHistoryId: string,
-    historyTypes?: ('messageAdded' | 'messageDeleted')[],
+    historyTypes?: (
+      | 'messageAdded'
+      | 'messageDeleted'
+      | 'labelAdded'
+      | 'labelRemoved'
+    )[],
     labelId?: string,
   ): Promise<{
     history: gmail_v1.Schema$History[];

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts
@@ -29,6 +29,7 @@ const createMockFolder = (
 describe('GmailGetMessageListService', () => {
   let service: GmailGetMessageListService;
   let oAuth2ClientManagerService: OAuth2ClientManagerService;
+  let gmailGetHistoryService: GmailGetHistoryService;
 
   const mockConnectedAccount: Pick<
     ConnectedAccountWorkspaceEntity,
@@ -78,6 +79,9 @@ describe('GmailGetMessageListService', () => {
     );
     oAuth2ClientManagerService = module.get<OAuth2ClientManagerService>(
       OAuth2ClientManagerService,
+    );
+    gmailGetHistoryService = module.get<GmailGetHistoryService>(
+      GmailGetHistoryService,
     );
   });
 
@@ -447,6 +451,128 @@ describe('GmailGetMessageListService', () => {
       expect(callArgs.q).toContain('-label:spam');
       expect(callArgs.q).toContain('-category:promotions');
       expect(callArgs.q).not.toContain('label:inbox');
+    });
+  });
+
+  describe('incremental sync with selected folders', () => {
+    it('should include messages added to synced folders by label changes', async () => {
+      const mockGmailClient = {
+        users: {
+          messages: {
+            get: jest.fn(),
+          },
+          threads: {
+            get: jest.fn(),
+          },
+        },
+      };
+
+      jest.spyOn(google, 'gmail').mockReturnValue(mockGmailClient as never);
+      (
+        oAuth2ClientManagerService.getGoogleOAuth2Client as jest.Mock
+      ).mockResolvedValue({});
+      (gmailGetHistoryService.getHistory as jest.Mock).mockResolvedValue({
+        history: [
+          {
+            labelsAdded: [
+              {
+                labelIds: ['Label_custom'],
+                message: { id: 'message-added-by-label' },
+              },
+            ],
+          },
+        ],
+        historyId: 'next-history-id',
+      });
+      (
+        gmailGetHistoryService.getMessageIdsFromHistory as jest.Mock
+      ).mockResolvedValue({
+        messagesAdded: [],
+        messagesDeleted: [],
+      });
+
+      const result = await service.getMessageLists({
+        messageChannel: {
+          syncCursor: 'history-100',
+          id: 'my-id',
+          messageFolderImportPolicy: MessageFolderImportPolicy.SELECTED_FOLDERS,
+        },
+        connectedAccount: mockConnectedAccount,
+        messageFolders: [
+          createMockFolder({
+            name: 'Custom',
+            externalId: 'Label_custom',
+            isSynced: true,
+          }),
+        ],
+      });
+
+      expect(result[0].messageExternalIds).toEqual(['message-added-by-label']);
+    });
+
+    it('should include reply messages when a synced label exists on another message in thread', async () => {
+      const mockGmailClient = {
+        users: {
+          messages: {
+            get: jest.fn().mockResolvedValue({
+              data: {
+                id: 'reply-message-id',
+                threadId: 'thread-1',
+                labelIds: ['INBOX'],
+              },
+            }),
+          },
+          threads: {
+            get: jest.fn().mockResolvedValue({
+              data: {
+                id: 'thread-1',
+                messages: [
+                  { id: 'original-message', labelIds: ['Label_custom'] },
+                  { id: 'reply-message-id', labelIds: ['INBOX'] },
+                ],
+              },
+            }),
+          },
+        },
+      };
+
+      jest.spyOn(google, 'gmail').mockReturnValue(mockGmailClient as never);
+      (
+        oAuth2ClientManagerService.getGoogleOAuth2Client as jest.Mock
+      ).mockResolvedValue({});
+      (gmailGetHistoryService.getHistory as jest.Mock).mockResolvedValue({
+        history: [],
+        historyId: 'next-history-id',
+      });
+      (
+        gmailGetHistoryService.getMessageIdsFromHistory as jest.Mock
+      ).mockResolvedValue({
+        messagesAdded: ['reply-message-id'],
+        messagesDeleted: [],
+      });
+
+      const result = await service.getMessageLists({
+        messageChannel: {
+          syncCursor: 'history-100',
+          id: 'my-id',
+          messageFolderImportPolicy: MessageFolderImportPolicy.SELECTED_FOLDERS,
+        },
+        connectedAccount: mockConnectedAccount,
+        messageFolders: [
+          createMockFolder({
+            name: 'Custom',
+            externalId: 'Label_custom',
+            isSynced: true,
+          }),
+        ],
+      });
+
+      expect(result[0].messageExternalIds).toEqual(['reply-message-id']);
+      expect(mockGmailClient.users.threads.get).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: 'thread-1',
+        }),
+      );
     });
   });
 });

--- a/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts
+++ b/packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.ts
@@ -1,7 +1,8 @@
 import { Injectable, Logger } from '@nestjs/common';
 
+import { batchFetchImplementation } from '@jrmdayn/googleapis-batcher';
 import { isNonEmptyString } from '@sniptt/guards';
-import { google } from 'googleapis';
+import { type gmail_v1, google } from 'googleapis';
 
 import { OAuth2ClientManagerService } from 'src/modules/connected-account/oauth2-client-manager/services/oauth2-client-manager.service';
 import { type ConnectedAccountWorkspaceEntity } from 'src/modules/connected-account/standard-objects/connected-account.workspace-entity';
@@ -24,11 +25,166 @@ import { type GetMessageListsResponse } from 'src/modules/messaging/message-impo
 @Injectable()
 export class GmailGetMessageListService {
   private readonly logger = new Logger(GmailGetMessageListService.name);
+  private readonly gmailBatchRequestMaxSize = 50;
   constructor(
     private readonly gmailGetHistoryService: GmailGetHistoryService,
     private readonly oAuth2ClientManagerService: OAuth2ClientManagerService,
     private readonly gmailMessageListFetchErrorHandler: GmailMessageListFetchErrorHandler,
   ) {}
+
+  private getSyncedFolderExternalIds(
+    messageFolders: Pick<
+      MessageFolderWorkspaceEntity,
+      'name' | 'externalId' | 'isSynced' | 'parentFolderId'
+    >[],
+  ): string[] {
+    return messageFolders
+      .filter(
+        (folder) => folder.isSynced && isNonEmptyString(folder.externalId),
+      )
+      .map((folder) => folder.externalId);
+  }
+
+  private async getMessagesWithMetadata(
+    gmailClient: gmail_v1.Gmail,
+    messageIds: string[],
+  ): Promise<gmail_v1.Schema$Message[]> {
+    const metadataPromises = messageIds.map((messageId) =>
+      gmailClient.users.messages
+        .get({
+          userId: 'me',
+          id: messageId,
+          format: 'metadata',
+          metadataHeaders: [],
+        })
+        .then((response) => response.data)
+        .catch((error) => {
+          this.gmailMessageListFetchErrorHandler.handleError(error);
+
+          return null;
+        }),
+    );
+
+    const metadata = await Promise.all(metadataPromises);
+
+    return metadata.filter(
+      (message): message is gmail_v1.Schema$Message => !!message,
+    );
+  }
+
+  private getLabelChangedMessageIds(
+    history: gmail_v1.Schema$History[],
+    syncedFolderExternalIds: string[],
+  ): { messageIdsAddedByLabel: string[]; messageIdsRemovedByLabel: string[] } {
+    const messageIdsAddedByLabel = new Set<string>();
+    const messageIdsRemovedByLabel = new Set<string>();
+
+    for (const historyItem of history) {
+      const labelsAdded = historyItem.labelsAdded ?? [];
+      const labelsRemoved = historyItem.labelsRemoved ?? [];
+
+      for (const labelAdded of labelsAdded) {
+        const labelIds = labelAdded.labelIds ?? [];
+        const messageId = labelAdded.message?.id;
+
+        if (
+          messageId &&
+          labelIds.some((labelId) => syncedFolderExternalIds.includes(labelId))
+        ) {
+          messageIdsAddedByLabel.add(messageId);
+        }
+      }
+
+      for (const labelRemoved of labelsRemoved) {
+        const labelIds = labelRemoved.labelIds ?? [];
+        const messageId = labelRemoved.message?.id;
+
+        if (
+          messageId &&
+          labelIds.some((labelId) => syncedFolderExternalIds.includes(labelId))
+        ) {
+          messageIdsRemovedByLabel.add(messageId);
+        }
+      }
+    }
+
+    return {
+      messageIdsAddedByLabel: Array.from(messageIdsAddedByLabel),
+      messageIdsRemovedByLabel: Array.from(messageIdsRemovedByLabel),
+    };
+  }
+
+  private async getReplyMessageIdsFromSyncedThreads(
+    gmailClient: gmail_v1.Gmail,
+    messagesAddedByHistory: string[],
+    syncedFolderExternalIds: string[],
+  ): Promise<string[]> {
+    if (
+      messagesAddedByHistory.length === 0 ||
+      syncedFolderExternalIds.length === 0
+    ) {
+      return [];
+    }
+
+    const messagesMetadata = await this.getMessagesWithMetadata(
+      gmailClient,
+      messagesAddedByHistory,
+    );
+
+    const threadIds = Array.from(
+      new Set(
+        messagesMetadata
+          .map((message) => message.threadId)
+          .filter(isNonEmptyString),
+      ),
+    );
+
+    const threadPromises = threadIds.map((threadId) =>
+      gmailClient.users.threads
+        .get({
+          userId: 'me',
+          id: threadId,
+          format: 'metadata',
+          metadataHeaders: [],
+        })
+        .then((response) => response.data)
+        .catch((error) => {
+          this.gmailMessageListFetchErrorHandler.handleError(error);
+
+          return null;
+        }),
+    );
+
+    const threads = (await Promise.all(threadPromises)).filter(
+      (thread): thread is gmail_v1.Schema$Thread => !!thread,
+    );
+
+    const syncedThreadIds = new Set(
+      threads
+        .filter((thread) =>
+          (thread.messages ?? []).some((threadMessage) =>
+            (threadMessage.labelIds ?? []).some((labelId) =>
+              syncedFolderExternalIds.includes(labelId),
+            ),
+          ),
+        )
+        .map((thread) => thread.id)
+        .filter(isNonEmptyString),
+    );
+
+    return messagesMetadata
+      .filter((message) => {
+        const messageLabelIds = message.labelIds ?? [];
+
+        const isInSyncedFolder = messageLabelIds.some((labelId) =>
+          syncedFolderExternalIds.includes(labelId),
+        );
+
+        return isInSyncedFolder || syncedThreadIds.has(message.threadId ?? '');
+      })
+      .map((message) => message.id)
+      .filter(isNonEmptyString);
+  }
 
   private async getMessageListWithoutCursor(
     connectedAccount: Pick<
@@ -48,9 +204,14 @@ export class GmailGetMessageListService {
       await this.oAuth2ClientManagerService.getGoogleOAuth2Client(
         connectedAccount,
       );
+    const batchedFetchImplementation = batchFetchImplementation({
+      maxBatchSize: this.gmailBatchRequestMaxSize,
+    });
+
     const gmailClient = google.gmail({
       version: 'v1',
       auth: oAuth2Client,
+      fetchImplementation: batchedFetchImplementation,
     });
 
     let pageToken: string | undefined;
@@ -169,9 +330,14 @@ export class GmailGetMessageListService {
       await this.oAuth2ClientManagerService.getGoogleOAuth2Client(
         connectedAccount,
       );
+    const batchedFetchImplementation = batchFetchImplementation({
+      maxBatchSize: this.gmailBatchRequestMaxSize,
+    });
+
     const gmailClient = google.gmail({
       version: 'v1',
       auth: oAuth2Client,
+      fetchImplementation: batchedFetchImplementation,
     });
 
     if (!isNonEmptyString(messageChannel.syncCursor)) {
@@ -186,10 +352,41 @@ export class GmailGetMessageListService {
       await this.gmailGetHistoryService.getHistory(
         gmailClient,
         messageChannel.syncCursor,
+        ['messageAdded', 'messageDeleted', 'labelAdded', 'labelRemoved'],
       );
 
-    const { messagesAdded, messagesDeleted } =
-      await this.gmailGetHistoryService.getMessageIdsFromHistory(history);
+    const {
+      messagesAdded: historyMessagesAdded,
+      messagesDeleted: historyMessagesDeleted,
+    } = await this.gmailGetHistoryService.getMessageIdsFromHistory(history);
+
+    const syncedFolderExternalIds =
+      this.getSyncedFolderExternalIds(messageFolders);
+
+    const { messageIdsAddedByLabel, messageIdsRemovedByLabel } =
+      this.getLabelChangedMessageIds(history, syncedFolderExternalIds);
+
+    const replyMessageIds =
+      messageChannel.messageFolderImportPolicy ===
+      MessageFolderImportPolicy.SELECTED_FOLDERS
+        ? await this.getReplyMessageIdsFromSyncedThreads(
+            gmailClient,
+            historyMessagesAdded,
+            syncedFolderExternalIds,
+          )
+        : [];
+
+    const messagesAdded = Array.from(
+      new Set([
+        ...historyMessagesAdded,
+        ...messageIdsAddedByLabel,
+        ...replyMessageIds,
+      ]),
+    );
+
+    const messagesDeleted = Array.from(
+      new Set([...historyMessagesDeleted, ...messageIdsRemovedByLabel]),
+    ).filter((messageId) => !messagesAdded.includes(messageId));
 
     if (!nextSyncCursor) {
       throw new MessageImportDriverException(


### PR DESCRIPTION
### Motivation
- Incremental Gmail sync for `MessageFolderImportPolicy.SELECTED_FOLDERS` missed messages when labels were added/removed or when a reply lacked the synced label but lived in a thread containing a synced message.
- The Gmail History API supports label change events and thread-level metadata can be used to determine when replies should be imported, so the importer must incorporate those sources into the import pipeline.

### Description
- Extend history types requested from the Gmail History API to include `'labelAdded'` and `'labelRemoved'` by updating `GmailGetHistoryService.getHistory` to accept the expanded types list.
- Update `GmailGetMessageListService` to: use a batched fetch implementation (`@jrmdayn/googleapis-batcher`) for metadata/thread calls, extract synced folder external IDs, detect message IDs coming from label changes, and merge those with `messageAdded`/`messageDeleted` events.
- Add thread-aware handling that fetches message metadata and thread metadata to include replies in incremental sync when any message in the same thread has a synced label.
- Add unit tests covering the two missed-import cases by extending `gmail-get-message-list.service.spec.ts` with tests for label-added imports and reply-imports driven by synced labels on thread messages.
- Files changed: `gmail-get-message-list.service.ts`, `gmail-get-history.service.ts`, and `gmail-get-message-list.service.spec.ts` with formatting applied by `prettier`.

### Testing
- Ran the updated unit spec `packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-message-list.service.spec.ts` via the project test pipeline and it passed (incremental scenarios included).
- Ran `packages/twenty-server/src/modules/messaging/message-import-manager/drivers/gmail/services/gmail-get-history.service.spec.ts` and existing history tests remained valid after expanding the accepted history types.
- Direct ad-hoc `jest` invocations failed initially due to workspace invocation differences and module resolution outside the configured NX test runner, and `nx`-based lint surfaced unrelated workspace type errors; these are environmental and not caused by the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e8462af048322b2e6d7ab81f6769f)